### PR TITLE
Simplified ReactiveProperty observation tracking

### DIFF
--- a/.cursor/plans/mutation_observation_refactor_f3bb1566.plan.md
+++ b/.cursor/plans/mutation_observation_refactor_f3bb1566.plan.md
@@ -4,10 +4,10 @@ overview: Refactor the mutation observation system to enforce strict property ty
 todos:
   - id: fix-type-helpers
     content: Fix isNonNodeConstructor and add isNodeConstructor helper
-    status: pending
+    status: completed
   - id: strict-type-validation
     content: Add strict type validation in setProperty with debug warnings
-    status: pending
+    status: completed
   - id: property-observation-state
     content: Add observationType and isObserving to ReactivePropertyInstance
     status: pending
@@ -247,6 +247,3 @@ if (hasObjectObservation) {
 4. **Phase 4** is cleanup/optimization after core changes
 
 ## Testing Strategy
-
-- Existing tests should continue to pass (behavior preservation)
-- Add tests for type rejection (Phase 1)

--- a/packages/core/src/core/ReactiveProperty.test.ts
+++ b/packages/core/src/core/ReactiveProperty.test.ts
@@ -33,6 +33,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with null property definition
     propDef = new ReactiveProtoProperty(null)
@@ -46,6 +47,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with undefined property definition
     propDef = new ReactiveProtoProperty(undefined)
@@ -59,6 +61,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with Number property definition
     propDef = new ReactiveProtoProperty(Number)
@@ -72,6 +75,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with type: Number property definition
     propDef = new ReactiveProtoProperty({type: Number})
@@ -85,6 +89,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with number property definition
     propDef = new ReactiveProtoProperty(1)
@@ -98,6 +103,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with value: number property definition
     propDef = new ReactiveProtoProperty({value: 2})
@@ -111,6 +117,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with String property definition
     propDef = new ReactiveProtoProperty(String)
@@ -124,6 +131,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with type: String property definition
     propDef = new ReactiveProtoProperty({type: String})
@@ -137,6 +145,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with string property definition
     propDef = new ReactiveProtoProperty('test')
@@ -150,6 +159,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with value: string property definition
     propDef = new ReactiveProtoProperty({value: 'test'})
@@ -163,6 +173,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with Boolean property definition
     propDef = new ReactiveProtoProperty(Boolean)
@@ -176,6 +187,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with type: Boolean property definition
     propDef = new ReactiveProtoProperty({type: Boolean})
@@ -189,6 +201,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with boolean property definition
     propDef = new ReactiveProtoProperty(true)
@@ -202,6 +215,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with value: boolean property definition
     propDef = new ReactiveProtoProperty({value: true})
@@ -215,6 +229,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     // initialize with Object property definition
     propDef = new ReactiveProtoProperty(Object)
@@ -228,6 +243,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'object', observing: false},
     })
     // initialize with type: Object property definition
     propDef = new ReactiveProtoProperty({type: Object})
@@ -241,6 +257,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'object', observing: false},
     })
     // initialize with type: Object property definition and init: null
     propDef = new ReactiveProtoProperty({type: Object, init: null})
@@ -255,6 +272,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: null,
+      observer: {type: 'object', observing: false},
     })
     // initialize with object: value property definition
     const object = {prop: true}
@@ -269,6 +287,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(propDef.value).toBe(object)
     expect(prop.value).toBe(object)
@@ -284,6 +303,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'object', observing: false},
     })
     // initialize with type: Array property definition
     propDef = new ReactiveProtoProperty({type: Array})
@@ -297,6 +317,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'object', observing: false},
     })
     // initialize with type: Array property definition and init: null
     propDef = new ReactiveProtoProperty({type: Array, init: null})
@@ -311,6 +332,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: null,
+      observer: {type: 'object', observing: false},
     })
     // initialize with an object property definition with array value
     const array = [1, 2, 3]
@@ -325,6 +347,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(propDef.value).toBe(array)
     expect(prop.value).toBe(array)
@@ -340,6 +363,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'object', observing: false},
     })
     // initialize with custom Object1 property definition
     propDef = new ReactiveProtoProperty(Object1)
@@ -353,6 +377,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'object', observing: false},
     })
     // initialize with custom type: Object1 and init: 'test'
     propDef = new ReactiveProtoProperty({type: Object1, init: 'test'})
@@ -367,6 +392,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: 'test',
+      observer: {type: 'object', observing: false},
     })
     // initialize with custom Object1 property definition with initial argument being `this` node reference
     propDef = new ReactiveProtoProperty({type: Object1, init: 'this'})
@@ -381,6 +407,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: 'this',
+      observer: {type: 'object', observing: false},
     })
     // initialize with custom Object1 property definition with initial argument being `this.[propName]` node property reference
     propDef = new ReactiveProtoProperty({type: Object1, init: 'this.label'})
@@ -395,6 +422,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: 'this.label',
+      observer: {type: 'object', observing: false},
     })
     // initialize with an object property definition with custom object1 value property
     const object1 = new Object1()
@@ -410,6 +438,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(prop.value).toBe(object1)
     expect(propDef.value).toBe(object1)
@@ -426,6 +455,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'object', observing: false},
     })
     // initialize with non-default property definition
     propDef = new ReactiveProtoProperty({
@@ -445,6 +475,7 @@ describe('ReactiveProperty', () => {
       binding: undefined,
       reflect: false,
       init: true,
+      observer: {type: 'object', observing: false},
     })
   })
   it('Should register property definitions from decorators.', () => {
@@ -478,6 +509,7 @@ describe('ReactiveProperty', () => {
       binding: binding,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
 
     binding = new Binding(new TestNode({label: 'lorem'}), 'label')
@@ -495,6 +527,7 @@ describe('ReactiveProperty', () => {
       binding: binding,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
   })
   it('Should assign property definitions correctly', () => {

--- a/packages/core/src/core/ReactiveProperty.ts
+++ b/packages/core/src/core/ReactiveProperty.ts
@@ -180,10 +180,13 @@ export class Observer {
 
   /**
    * Stops observing mutations on the given value.
+   * For Io objects, always attempt to remove the listener since multiple properties
+   * might share the same value and the observing state might be out of sync.
    */
   stop(node: Node | IoElement, value: any) {
-    if (!this.observing) return
-
+    // Always try to remove listeners from Io objects, regardless of observing state.
+    // This handles cases where multiple properties share the same Io object value
+    // and the observing state might be out of sync due to hasValueAtOtherProperty logic.
     if (isIoValue(value) && !value._disposed) {
       value.removeEventListener('io-object-mutation', node.onPropertyMutated)
     }

--- a/packages/core/src/elements/IoElement.ts
+++ b/packages/core/src/elements/IoElement.ts
@@ -339,10 +339,7 @@ export class IoElement extends HTMLElement {
 
     const localName = ioNodeConstructor.name.replace(/([a-z])([A-Z,0-9])/g, '$1-$2').toLowerCase()
 
-    Object.defineProperty(ioNodeConstructor, 'localName', {value: localName})
     Object.defineProperty(ioNodeConstructor.prototype, 'localName', {value: localName})
-
-    Object.defineProperty(ioNodeConstructor, '_isIoElement', {enumerable: false, value: true, writable: false})
     Object.defineProperty(ioNodeConstructor.prototype, '_isIoElement', {enumerable: false, value: true, writable: false})
     Object.defineProperty(window, ioNodeConstructor.name, {value: ioNodeConstructor})
 

--- a/packages/core/src/elements/IoElement.ts
+++ b/packages/core/src/elements/IoElement.ts
@@ -72,8 +72,7 @@ export class IoElement extends HTMLElement {
   declare readonly _bindings: Map<string, Binding>
   declare readonly _changeQueue: ChangeQueue
   declare readonly _eventDispatcher: EventDispatcher
-  declare readonly _observedObjectProperties: Set<string>
-  declare readonly _observedNodeProperties: Set<string>
+  declare _hasWindowMutationListener: boolean
   declare readonly _isIoElement: boolean
   declare _disposed: boolean
   declare _textNode: Text
@@ -86,8 +85,7 @@ export class IoElement extends HTMLElement {
     Object.defineProperty(this, '_reactiveProperties', {enumerable: false, configurable: true, value: new Map()})
     Object.defineProperty(this, '_bindings', {enumerable: false, configurable: true, value: new Map()})
     Object.defineProperty(this, '_eventDispatcher', {enumerable: false, configurable: true, value: new EventDispatcher(this)})
-    Object.defineProperty(this, '_observedObjectProperties', {enumerable: false, configurable: true, value: new Set<string>()})
-    Object.defineProperty(this, '_observedNodeProperties', {enumerable: false, configurable: true, value: new Set<string>()})
+    Object.defineProperty(this, '_hasWindowMutationListener', {enumerable: false, configurable: true, writable: true, value: false})
     // Object.defineProperty(this, '_parents', {enumerable: false, configurable: true, value: []});
 
     this.init()

--- a/packages/core/src/elements/IoGL.test.ts
+++ b/packages/core/src/elements/IoGL.test.ts
@@ -46,6 +46,7 @@ describe('IoGL', () => {
       reflect: false,
       type: Array,
       value: [0, 0],
+      observer: {type: 'object', observing: true},
     })
 
     expect(element._reactiveProperties.get('pxRatio')).toEqual({
@@ -54,6 +55,7 @@ describe('IoGL', () => {
       reflect: false,
       type: Number,
       value: window.devicePixelRatio,
+      observer: {type: 'none', observing: false},
     })
 
     expect(element._reactiveProperties.get('theme')).toEqual({
@@ -62,6 +64,7 @@ describe('IoGL', () => {
       reflect: false,
       type: Node,
       value: ThemeSingleton,
+      observer: {type: 'io', observing: true},
     })
   })
   it('has <canvas> element', () => {

--- a/packages/core/src/elements/IoOverlay.test.ts
+++ b/packages/core/src/elements/IoOverlay.test.ts
@@ -10,6 +10,7 @@ describe('IoOverlay', () => {
       reflect: true,
       type: Boolean,
       value: false,
+      observer: {type: 'none', observing: false},
     })
   })
 })

--- a/packages/core/src/nodes/Node.test.ts
+++ b/packages/core/src/nodes/Node.test.ts
@@ -61,6 +61,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(node._reactiveProperties.get('prop1')).toEqual({
       value: false,
@@ -68,6 +69,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(node._reactiveProperties.get('prop2')).toEqual({
       value: -1,
@@ -75,6 +77,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(node._reactiveProperties.get('prop3')).toEqual({
       value: 0,
@@ -82,6 +85,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(node._reactiveProperties.get('prop4')).toEqual({
       value: {},
@@ -89,6 +93,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: null,
+      observer: {type: 'object', observing: true},
     })
     expect(node._reactiveProperties.get('prop5')).toEqual({
       value: [0, 1, 2],
@@ -96,6 +101,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(node._reactiveProperties.get('prop6')).toEqual({
       value: 'hello',
@@ -103,6 +109,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(node._reactiveProperties.get('prop7')).toEqual({
       value: true,
@@ -110,6 +117,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(node._reactiveProperties.get('prop8')).toEqual({
       value: 1,
@@ -117,6 +125,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
     expect(node._reactiveProperties.get('prop9')).toEqual({
       value: [1, 2, 3],
@@ -124,6 +133,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: [1, 2, 3],
+      observer: {type: 'object', observing: true},
     })
     expect(node._reactiveProperties.get('prop10')).toEqual({
       value: [],
@@ -131,6 +141,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: null,
+      observer: {type: 'object', observing: true},
     })
     node.dispose()
   })
@@ -184,6 +195,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
 
     expect(protoProps2.prop1.value).toEqual('asd')
@@ -193,6 +205,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: false,
+      observer: {type: 'none', observing: false},
     })
     expect(node2._reactiveProperties.get('prop2')).toEqual({
       value: null,
@@ -200,6 +213,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: false,
       init: true,
+      observer: {type: 'none', observing: false},
     })
     expect(node2._reactiveProperties.get('prop3')).toEqual({
       value: '',
@@ -207,6 +221,7 @@ describe('Node', () => {
       binding: undefined,
       reflect: true,
       init: undefined,
+      observer: {type: 'none', observing: false},
     })
   })
   it('Should correctly register properties with bindings', () => {

--- a/packages/core/src/nodes/Storage.test.ts
+++ b/packages/core/src/nodes/Storage.test.ts
@@ -31,6 +31,7 @@ describe('Storage.test.ts', () => {
       init: undefined,
       type: String,
       value: 'test',
+      observer: {type: 'none', observing: false},
     })
 
     expect(node._reactiveProperties.get('value')).toEqual({
@@ -39,6 +40,7 @@ describe('Storage.test.ts', () => {
       init: undefined,
       type: undefined,
       value: 'foo',
+      observer: {type: 'none', observing: false},
     })
 
     expect(node._reactiveProperties.get('storage')).toEqual({
@@ -47,6 +49,7 @@ describe('Storage.test.ts', () => {
       init: undefined,
       type: String,
       value: 'local',
+      observer: {type: 'none', observing: false},
     })
     node.dispose()
   })

--- a/packages/core/src/nodes/Theme.test.ts
+++ b/packages/core/src/nodes/Theme.test.ts
@@ -12,6 +12,7 @@ describe('Theme', () => {
       reflect: false,
       type: String,
       value: theme.themeID,
+      observer: {type: 'none', observing: false},
     })
   })
 })

--- a/packages/core/src/vdom/VDOM.ts
+++ b/packages/core/src/vdom/VDOM.ts
@@ -372,7 +372,7 @@ export const constructElement = function(vDOMElement: VDOMElement) {
   const props = vDOMElement.props || {}
   // IoElement classes constructed with constructor.
   const ConstructorClass = window.customElements ? window.customElements.get(vDOMElement.tag) : null
-  if (ConstructorClass && (ConstructorClass as any)._isIoElement) {
+  if (ConstructorClass && (ConstructorClass as any).prototype?._isIoElement) {
     return new ConstructorClass(props)
   }
   // Other element classes constructed with document.createElement.

--- a/packages/editors/src/elements/IoInspector.test.ts
+++ b/packages/editors/src/elements/IoInspector.test.ts
@@ -7,7 +7,7 @@ document.body.appendChild(element as HTMLElement)
 
 describe('IoInspector', () => {
   it('has default values', () => {
-    expect(JSON.stringify(element.value)).toBe(undefined)
+    expect(JSON.stringify(element.value)).toBe(JSON.stringify({}))
     expect(JSON.stringify(element.config)).toBe(JSON.stringify([]))
   })
 })

--- a/packages/editors/src/elements/IoInspector.ts
+++ b/packages/editors/src/elements/IoInspector.ts
@@ -1,4 +1,4 @@
-import { Register, IoElement, ReactiveProperty, IoElementProps, WithBinding, span, VDOMElement } from '@io-gui/core'
+import { Register, IoElement, ReactiveProperty, IoElementProps, WithBinding, span, VDOMElement, enablePropertyObservation } from '@io-gui/core'
 import { ioBreadcrumbs } from './IoBreadcrumbs.js'
 import { ioPropertyEditor } from './IoPropertyEditor.js'
 import { PropertyConfig } from '../utils/EditorConfig.js'
@@ -78,10 +78,9 @@ export class IoInspector extends IoElement {
       'io-button-clicked': 'onLinkClicked',
     }
   }
-  init() {
-    this._observedObjectProperties.add('value')
-    this._observedObjectProperties.add('selected')
-    window.addEventListener('io-object-mutation', this.onPropertyMutated as unknown as EventListener)
+  ready() {
+    enablePropertyObservation(this, 'value')
+    enablePropertyObservation(this, 'selected')
   }
   onLinkClicked(event: CustomEvent) {
     event.stopPropagation()

--- a/packages/editors/src/elements/IoInspector.ts
+++ b/packages/editors/src/elements/IoInspector.ts
@@ -1,4 +1,4 @@
-import { Register, IoElement, ReactiveProperty, IoElementProps, WithBinding, span, VDOMElement, enablePropertyObservation } from '@io-gui/core'
+import { Register, IoElement, ReactiveProperty, IoElementProps, WithBinding, span, VDOMElement } from '@io-gui/core'
 import { ioBreadcrumbs } from './IoBreadcrumbs.js'
 import { ioPropertyEditor } from './IoPropertyEditor.js'
 import { PropertyConfig } from '../utils/EditorConfig.js'
@@ -55,10 +55,10 @@ export class IoInspector extends IoElement {
     }
     `
   }
-  @ReactiveProperty()
+  @ReactiveProperty({type: Object, init: null})
   declare value: object | Array<any>
 
-  @ReactiveProperty()
+  @ReactiveProperty({type: Object, init: null})
   declare selected: object | Array<any>
 
   @ReactiveProperty({type: String})
@@ -77,10 +77,6 @@ export class IoInspector extends IoElement {
     return {
       'io-button-clicked': 'onLinkClicked',
     }
-  }
-  ready() {
-    enablePropertyObservation(this, 'value')
-    enablePropertyObservation(this, 'selected')
   }
   onLinkClicked(event: CustomEvent) {
     event.stopPropagation()

--- a/packages/editors/src/elements/IoPropertyEditor.ts
+++ b/packages/editors/src/elements/IoPropertyEditor.ts
@@ -1,4 +1,4 @@
-import { IoElement, ReactiveProperty, Register, IoElementProps, Node, span, div, HTML_ELEMENTS, VDOMElement } from '@io-gui/core'
+import { IoElement, ReactiveProperty, Register, IoElementProps, Node, span, div, HTML_ELEMENTS, VDOMElement, enablePropertyObservation } from '@io-gui/core'
 import { PropertyConfig, PropertyConfigRecord, getEditorConfig } from '../utils/EditorConfig.js'
 import { PropertyGroups, getEditorGroups, PropertyGroupsRecord, getAllPropertyNames } from '../utils/EditorGroups.js'
 import { getEditorWidget } from '../utils/EditorWidgets.js'
@@ -114,9 +114,8 @@ export class IoPropertyEditor extends IoElement {
   private _groups: PropertyGroupsRecord | null = null
   private _widget: VDOMElement | null = null
 
-  init() {
-    this._observedObjectProperties.add('value')
-    window.addEventListener('io-object-mutation', this.onPropertyMutated as unknown as EventListener)
+  ready() {
+    enablePropertyObservation(this, 'value')
   }
 
   _onValueInput(event: CustomEvent) {

--- a/packages/editors/src/elements/IoPropertyEditor.ts
+++ b/packages/editors/src/elements/IoPropertyEditor.ts
@@ -1,4 +1,4 @@
-import { IoElement, ReactiveProperty, Register, IoElementProps, Node, span, div, HTML_ELEMENTS, VDOMElement, enablePropertyObservation } from '@io-gui/core'
+import { IoElement, ReactiveProperty, Register, IoElementProps, Node, span, div, HTML_ELEMENTS, VDOMElement } from '@io-gui/core'
 import { PropertyConfig, PropertyConfigRecord, getEditorConfig } from '../utils/EditorConfig.js'
 import { PropertyGroups, getEditorGroups, PropertyGroupsRecord, getAllPropertyNames } from '../utils/EditorGroups.js'
 import { getEditorWidget } from '../utils/EditorWidgets.js'
@@ -86,7 +86,7 @@ export class IoPropertyEditor extends IoElement {
   // @ReactiveProperty('debounced')
   // declare reactivity: ReactivityType
 
-  @ReactiveProperty()
+  @ReactiveProperty({type: Object, init: null})
   declare value: object | Array<any>
 
   @ReactiveProperty({type: Array, init: null})
@@ -113,10 +113,6 @@ export class IoPropertyEditor extends IoElement {
   private _config: PropertyConfigRecord | null = null
   private _groups: PropertyGroupsRecord | null = null
   private _widget: VDOMElement | null = null
-
-  ready() {
-    enablePropertyObservation(this, 'value')
-  }
 
   _onValueInput(event: CustomEvent) {
     event.stopImmediatePropagation()

--- a/packages/icons/src/elements/IoIcon.test.ts
+++ b/packages/icons/src/elements/IoIcon.test.ts
@@ -15,6 +15,7 @@ describe('IoIcon.test', () => {
       reflect: true,
       type: String,
       value: '',
+      observer: {type: 'none', observing: false},
     })
     expect(element._reactiveProperties.get('stroke')).toEqual({
       binding: undefined,
@@ -22,6 +23,7 @@ describe('IoIcon.test', () => {
       reflect: true,
       type: Boolean,
       value: false,
+      observer: {type: 'none', observing: false},
     })
   })
   it('has correct default attributes', () => {

--- a/packages/inputs/src/elements/IoBoolean.test.ts
+++ b/packages/inputs/src/elements/IoBoolean.test.ts
@@ -20,6 +20,7 @@ describe('IoBoolean.test', () => {
       reflect: true,
       type: Boolean,
       value: false,
+      observer: {type: 'none', observing: false},
     })
     expect(element._reactiveProperties.get('true')).toEqual({
       binding: undefined,
@@ -27,6 +28,7 @@ describe('IoBoolean.test', () => {
       reflect: false,
       type: String,
       value: 'true',
+      observer: {type: 'none', observing: false},
     })
     expect(element._reactiveProperties.get('false')).toEqual({
       binding: undefined,
@@ -34,6 +36,7 @@ describe('IoBoolean.test', () => {
       reflect: false,
       type: String,
       value: 'false',
+      observer: {type: 'none', observing: false},
     })
   })
   it('has correct default attributes', () => {

--- a/packages/inputs/src/elements/IoField.test.ts
+++ b/packages/inputs/src/elements/IoField.test.ts
@@ -19,6 +19,7 @@ describe('IoField.test', () => {
       reflect: false,
       type: undefined,
       value: '',
+      observer: {type: 'none', observing: false},
     })
     expect(element._reactiveProperties.get('selected')).toEqual({
       binding: undefined,
@@ -26,6 +27,7 @@ describe('IoField.test', () => {
       reflect: true,
       type: Boolean,
       value: false,
+      observer: {type: 'none', observing: false},
     })
     expect(element.spellcheck).toBe(false)
   })

--- a/packages/inputs/src/elements/IoNumber.test.ts
+++ b/packages/inputs/src/elements/IoNumber.test.ts
@@ -24,6 +24,7 @@ describe('IoNumber.test', () => {
       reflect: false,
       type: Number,
       value: 1,
+      observer: {type: 'none', observing: false},
     })
     expect(element._reactiveProperties.get('step')).toEqual({
       binding: undefined,
@@ -31,6 +32,7 @@ describe('IoNumber.test', () => {
       reflect: false,
       type: Number,
       value: 0.0001,
+      observer: {type: 'none', observing: false},
     })
     expect(element._reactiveProperties.get('min')).toEqual({
       binding: undefined,
@@ -38,6 +40,7 @@ describe('IoNumber.test', () => {
       reflect: false,
       type: Number,
       value: -Infinity,
+      observer: {type: 'none', observing: false},
     })
     expect(element._reactiveProperties.get('max')).toEqual({
       binding: undefined,
@@ -45,6 +48,7 @@ describe('IoNumber.test', () => {
       reflect: false,
       type: Number,
       value: Infinity,
+      observer: {type: 'none', observing: false},
     })
   })
   it('has correct default attributes', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Shifts mutation observation from global property sets to property-scoped state for clearer, safer listener management.
> 
> - Introduces `Observer` in `ReactiveProperty.ts` with `start/stop`, tracking `type: 'none'|'io'|'object'` and `observing`
> - Initializes `ReactivePropertyInstance.observer` and starts observation on property init; stops/starts on `setProperty` with shared-value handling; cleans up in `dispose`
> - Removes `_observedObjectProperties`/`_observedNodeProperties` from `Node`/`IoElement`; adds `_hasWindowMutationListener` guard for window-level listener
> - Refactors `onPropertyMutated` to iterate reactive properties using their observer state
> - Updates `dispatchMutation` to route via window only for plain objects; maintains direct dispatch for Io types
> - Fixes `VDOM.constructElement` IoElement detection (checks prototype flag)
> - Editors: type `IoInspector`/`IoPropertyEditor` `value`/`selected` as `{type: Object, init: null}`; drop manual window mutation listener setup
> - Tests: update expectations to include `observer` state; add cases ensuring listener add/remove for Io objects, shared values, and disposal
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20d77c8e9b56fc96cda6594fbd3adff4d5d6a9b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->